### PR TITLE
fixes ghost's autolinking which breaks the HTML

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -25,7 +25,7 @@
             <span class="post-meta"><time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time> {{tags prefix="on "}}</span>
         </header>
         
-        <div id="content-holder" class="{{tags separator=" "}}">
+        <div id="content-holder" class="{{tags autolink="false" separator=" "}}">
             <h2 class="post-title"><a href="{{url}}">{{{title}}}</a></h2>
             <section class="post-excerpt">
                 <p>{{excerpt}}&hellip; <a class="read-more" href="{{url}}">&raquo;</a></p>

--- a/post.hbs
+++ b/post.hbs
@@ -24,7 +24,7 @@
 
         <span class="post-meta"><time datetime="{{date format="YYYY-MM-DD"}}">{{date format='DD MMM YYYY'}}</time> {{tags prefix="on " separator=" | "}}</span>
         
-        <div id="content-holder" class="{{tags separator=" "}}">
+        <div id="content-holder" class="{{tags autolink="false" separator=" "}}">
             <h1 class="post-title">{{{title}}}</h1>
 
             <section class="post-content">

--- a/tag.hbs
+++ b/tag.hbs
@@ -25,7 +25,7 @@
             <span class="post-meta"><time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time> {{tags prefix="on "}}</span>
         </header>
         
-        <div id="content-holder" class="{{tags separator=" "}}">
+        <div id="content-holder" class="{{tags autolink="false" separator=" "}}">
             <h2 class="post-title"><a href="{{url}}">{{{title}}}</a></h2>
             <section class="post-excerpt">
                 <p>{{excerpt}}&hellip; <a class="read-more" href="{{url}}">&raquo;</a></p>


### PR DESCRIPTION
I am using Ghost's hosting and I have noticed that there is an issue with [autolinking](http://docs.ghost.org/themes/#tags-helper) which breaks that HTML. 

My fix seems to work:
- http://shakedko.ghost.io/  
- http://shakedko.ghost.io/shlvm/
- http://shakedko.ghost.io/tag/hebrew/
